### PR TITLE
エラーハンドリングの基盤作成

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.17.1
 	github.com/labstack/echo/v4 v4.12.0
 	github.com/oapi-codegen/oapi-codegen/v2 v2.3.0
+	github.com/pkg/errors v0.9.1
 	go.uber.org/mock v0.4.0
 )
 
@@ -45,7 +46,6 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect

--- a/internal/app/errors.go
+++ b/internal/app/errors.go
@@ -1,0 +1,33 @@
+package app
+
+import (
+	"errors"
+
+	e "github.com/pkg/errors"
+)
+
+var (
+	InvalidParamsError  = errors.New("リクエストに不正な値が含まれています。")
+	NotFoundEntityError = errors.New("指定されたリソースが見つかりません。")
+
+	BadRequestErrors = errors.Join(
+		InvalidParamsError,
+	)
+
+	NotFoundErrors = errors.Join(
+		NotFoundEntityError,
+	)
+)
+
+func getStatusCode(err error) int {
+	code := 500
+	cause := e.Cause(err)
+
+	switch cause {
+	case BadRequestErrors:
+		code = 400
+	case NotFoundErrors:
+		code = 404
+	}
+	return code
+}

--- a/internal/app/middleware.go
+++ b/internal/app/middleware.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"fmt"
+
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 )
@@ -16,6 +18,7 @@ func InitMiddleware(e *echo.Echo) {
 }
 
 func CustomHttpErrorHandler(err error, c echo.Context) {
+	fmt.Printf("STACK TRACE:\n %+v\n", err)
 	if c.Response().Committed {
 		return
 	}

--- a/internal/app/middleware.go
+++ b/internal/app/middleware.go
@@ -7,9 +7,17 @@ import (
 
 func InitMiddleware(e *echo.Echo) {
 	e.Use(middleware.Recover())
+	e.HTTPErrorHandler = CustomHttpErrorHandler
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOrigins: []string{"http://localhost:8080"},
 		AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept},
 	})) // TODO: 動作確認
 	e.Use(middleware.Logger())
+}
+
+func CustomHttpErrorHandler(err error, c echo.Context) {
+	if c.Response().Committed {
+		return
+	}
+	c.JSON(getStatusCode(err), map[string]string{"error": err.Error()})
 }

--- a/internal/handler/grade_handler.go
+++ b/internal/handler/grade_handler.go
@@ -6,6 +6,7 @@ import (
 	"spocon-backend/internal/usecase"
 
 	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
 )
 
 type GradeHandler struct {
@@ -21,7 +22,7 @@ func NewGradeHandler(u usecase.GradeUsecase) GradeHandler {
 func (h *Handlers) GetGrades(c echo.Context) error {
 	grades, err := h.GradeHandler.GradeUsecase.GetGrades()
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, err)
+		return errors.Wrap(err, "グレード一覧の取得に失敗しました。")
 	}
 	res := a.ToGetGradesResponse(grades)
 	return c.JSON(http.StatusOK, res)

--- a/internal/infra/grade_repository_impl.go
+++ b/internal/infra/grade_repository_impl.go
@@ -28,7 +28,7 @@ func (ri *GradeRepositoryImpl) FetchAll() ([]g.Grade, error) {
 	for rows.Next() {
 		var grade g.Grade
 		if err := rows.Scan(&id, &grade.Name); err != nil {
-			return nil, errors.Wrap(err, "gradesレコードの変換処理に失敗しました。")
+			return nil, errors.Wrap(err, "gradeの型変換に失敗しました。")
 		}
 		grade.Id = g.NewGradeId(id)
 		grades = append(grades, grade)

--- a/internal/infra/grade_repository_impl.go
+++ b/internal/infra/grade_repository_impl.go
@@ -5,6 +5,7 @@ import (
 	g "spocon-backend/internal/domain/model/grade"
 
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/pkg/errors"
 )
 
 type GradeRepositoryImpl struct {
@@ -18,7 +19,7 @@ func NewGradeRepositoryImpl(db *sql.DB) *GradeRepositoryImpl {
 func (ri *GradeRepositoryImpl) FetchAll() ([]g.Grade, error) {
 	rows, err := ri.DB.Query("SELECT id, name FROM grades")
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gradesのレコード取得に失敗しました。")
 	}
 	defer rows.Close()
 
@@ -27,7 +28,7 @@ func (ri *GradeRepositoryImpl) FetchAll() ([]g.Grade, error) {
 	for rows.Next() {
 		var grade g.Grade
 		if err := rows.Scan(&id, &grade.Name); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "gradesレコードの変換処理に失敗しました。")
 		}
 		grade.Id = g.NewGradeId(id)
 		grades = append(grades, grade)

--- a/internal/usecase/grade_usecase.go
+++ b/internal/usecase/grade_usecase.go
@@ -3,6 +3,8 @@ package usecase
 import (
 	g "spocon-backend/internal/domain/model/grade"
 	r "spocon-backend/internal/domain/repository"
+
+	"github.com/pkg/errors"
 )
 
 type GradeUsecase struct {
@@ -18,7 +20,7 @@ func NewGradeUsecase(r r.GradeRepository) GradeUsecase {
 func (u *GradeUsecase) GetGrades() ([]g.Grade, error) {
 	grades, err := u.GradeRepository.FetchAll()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gradeのFetchAll()に失敗しました。")
 	}
 
 	return grades, nil


### PR DESCRIPTION
## やったこと

- APIレスポンスのステータスコードを制御処理追加
  - internal/app/errors.go
- スタックトレースを出力するように修正
  - CustomHttpErrorHandlerにprint文追加（errorsパッケージの型で返したら、errorsパッケージがFormatメソッドをスタックトレースを出力するような実装でオーバーライドしているので、print文を追加するだけでOK）
- errorを返す処理をerrorsパッケージのwrapを使うように修正
  - errorsパッケージの型を使うことで、スタックトレース出力される
  - wrapをすることで、どういう経路でエラーが出力されているかデバッグがしやすい（スタックトレースでも見ることはできるが、念の為）