### PR TITLE
Log基盤作成

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.22
+FROM golang:1.23
 
-RUN go install github.com/cosmtrek/air@v1.49.0
+RUN go install github.com/air-verse/air@latest
 
 WORKDIR /app
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"spocon-backend/internal/app"
 	"spocon-backend/internal/domain/service"
 	"spocon-backend/internal/handler"
@@ -13,6 +14,9 @@ import (
 )
 
 func main() {
+	logger := app.InitLogger(os.Stdout, os.Stderr)
+	util.InitAppLogger(logger)
+
 	e := echo.New()
 	app.InitMiddleware(e)
 

--- a/internal/app/logger.go
+++ b/internal/app/logger.go
@@ -1,8 +1,10 @@
 package app
 
 import (
+	"fmt"
 	"io"
 	"log/slog"
+	"runtime/debug"
 )
 
 type LogConfig struct {
@@ -44,7 +46,8 @@ func (s *SLogLogger) Warn(msg string) {
 }
 
 func (s *SLogLogger) Error(err error, msg string) {
-	s.outLogger.Error(msg)
+	combinedMsg := fmt.Sprintf("%s: %v", msg, err)
+	s.outLogger.Error(combinedMsg, "stacktrace", debug.Stack())
 }
 
 func newSlogger(conf *LogConfig) *SLogLogger {

--- a/internal/app/logger.go
+++ b/internal/app/logger.go
@@ -1,0 +1,77 @@
+package app
+
+import (
+	"io"
+	"log/slog"
+)
+
+type LogConfig struct {
+	Name   string
+	Level  string
+	Out    io.Writer
+	OutErr io.Writer
+}
+
+func NewLogConfig(name string, out io.Writer, outErr io.Writer) *LogConfig {
+	return &LogConfig{
+		Name:   name,
+		Level:  "debug", // TODO: 引数でConfigを受け取って、環境ごとに設定したい
+		Out:    out,
+		OutErr: outErr,
+	}
+}
+
+func InitLogger(out io.Writer, outErr io.Writer) *SLogLogger {
+	logConfig := NewLogConfig("app_log", out, outErr)
+	return newSlogger(logConfig)
+}
+
+type SLogLogger struct {
+	outLogger    *slog.Logger
+	outErrLogger *slog.Logger
+}
+
+func (s *SLogLogger) Debug(msg string) {
+	s.outLogger.Debug(msg)
+}
+
+func (s *SLogLogger) Info(msg string) {
+	s.outLogger.Info(msg)
+}
+
+func (s *SLogLogger) Warn(msg string) {
+	s.outLogger.Warn(msg)
+}
+
+func (s *SLogLogger) Error(err error, msg string) {
+	s.outLogger.Error(msg)
+}
+
+func newSlogger(conf *LogConfig) *SLogLogger {
+	var level slog.Level
+	switch conf.Level {
+	case "debug":
+		level = slog.LevelDebug
+	case "info":
+		level = slog.LevelInfo
+	case "warn":
+		level = slog.LevelWarn
+	case "error":
+		level = slog.LevelError
+	default:
+		level = slog.LevelInfo
+	}
+
+	sLogger := &SLogLogger{}
+
+	opts := &slog.HandlerOptions{
+		Level: level,
+	}
+	logger := slog.New(slog.NewJSONHandler(conf.Out, opts))
+	sLogger.outLogger = logger
+
+	errLogger := slog.New(slog.NewJSONHandler(conf.OutErr, opts))
+	sLogger.outErrLogger = errLogger
+
+	return sLogger
+}

--- a/internal/util/logger.go
+++ b/internal/util/logger.go
@@ -1,0 +1,46 @@
+package util
+
+var Logger *AppLogger
+
+type AppLogger struct {
+	logger GenericLogger
+}
+
+type GenericLogger interface {
+	Debug(msg string)
+	Info(msg string)
+	Warn(msg string)
+	Error(err error, msg string)
+}
+
+func InitAppLogger(logger GenericLogger) {
+	Logger = &AppLogger{logger: logger}
+}
+
+func (l *AppLogger) Debug(msg string) {
+	if l == nil || l.logger == nil {
+		return
+	}
+	l.logger.Debug(msg)
+}
+
+func (l *AppLogger) Info(msg string) {
+	if l == nil || l.logger == nil {
+		return
+	}
+	l.logger.Info(msg)
+}
+
+func (l *AppLogger) Warn(msg string) {
+	if l == nil || l.logger == nil {
+		return
+	}
+	l.logger.Warn(msg)
+}
+
+func (l *AppLogger) Error(err error, msg string) {
+	if l == nil || l.logger == nil {
+		return
+	}
+	l.logger.Error(err, msg)
+}


### PR DESCRIPTION
## やったこと

- internal.appパッケージ配下にlogger.goを追加
  - このファイルでlog/slogパッケージをoverrideしたログ出力の基盤を作成
  - internal.app.logger.goで公開しているメソッドはアプリケーションから直接参照しない（循環参照を避けるため）
- internal.utilパッケージ配下にlogger.goを追加
  - このファイルでアプリケーションから参照するログ出力のメソッドを提供
  - 上記の循環参照を避けるため、util側にアプリケーションから参照するloggerを作成

## ついでで変更したところ

- DockerfileのGolangとairのバージョンを更新

## 動作確認

アプリケーションにて下記の実装でログ出力ができることを確認
```
util.Logger.Info("log test")
```
