### PR TITLE
swagger-uiをdockerコンテナで立ち上げる

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,3 +24,11 @@ services:
       - 3306:3306
     volumes:
       - ./database/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+  swagger-ui:
+    image: swaggerapi/swagger-ui
+    ports:
+      - 8081:8080
+    environment:
+      SWAGGER_JSON: /openapi/openapi.yaml
+    volumes:
+      - ./openapi/openapi.yaml:/openapi/openapi.yaml

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -4,7 +4,8 @@ info:
   title: spocon-backend
   discription: spocon-backend Open API 
 servers:
-  - url: /
+  - url: http://localhost:1323
+    description: ローカル環境
 paths:
   /health:
     get:


### PR DESCRIPTION
## やったこと

- swagger-uiをコンテナで立ち上げて、ブラウザからAPI仕様の確認や動作確認をできるようにした

## 動作確認

- localhost:8081でアクセスして以下の画面が表示されたらOK
- APIを実行してみて正常に動作するか確認
![image](https://github.com/user-attachments/assets/a9a087e6-6893-4846-9406-2a54181648df)
